### PR TITLE
Simplify the README (move to docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,15 @@
 [![Coverage](https://codecov.io/gh/timholy/AggregateBy.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/timholy/AggregateBy.jl)
 [![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://timholy.github.io/AggregateBy.jl/dev)
 
-AggregateBy supports simple aggregation operations on iterable containers. Functions that might be called `countby` and `groupby` are instead composed of an aggregation and `By(f)` selector.
+AggregateBy supports simple aggregation operations on iterable containers. Functions that might (in other languages) be called `countby` and `groupby` are instead composed of two pieces, (1) an aggregation operation and (2) a `By(f)` selector. Some examples may help explain the general concept; see the [documentation](https://timholy.github.io/AggregateBy.jl/dev) for more detail.
 
 ## Examples
 
-All examples assume that you've executed `using AggregateBy` in the current session.
+These examples assume that you've executed `using AggregateBy` in the current session.
 
-To count all the letters in a string:
+To count all the letters in a string, ignoring case, use
 
-```julia
-julia> count(By(), "Hello")
-Dict{Char, Int64} with 4 entries:
-  'H' => 1
-  'l' => 2
-  'e' => 1
-  'o' => 1
-```
-
-If you also want to ignore case, then use
-
-```julia
+```jldoctest
 julia> count(By(lowercase), "HelLo")
 Dict{Char, Int64} with 4 entries:
   'h' => 1
@@ -32,25 +21,13 @@ Dict{Char, Int64} with 4 entries:
   'o' => 1
 ```
 
-and all characters will be converted to lowercase before counting them.
+To collect similar items, use `push!`:
 
-Or, combine multiple `sum(f, itr)` statements into a single command:
-
-```julia
-julia> sum(By(isodd), 1:11)
-Dict{Bool, Int64} with 2 entries:
-  0 => 30
-  1 => 36
-```
-
-or collect such items for further analysis:
-
-```julia
+```jldoctest
 julia> push!(By(isodd), 1:11)
 Dict{Bool, Vector{Int64}} with 2 entries:
   0 => [2, 4, 6, 8, 10]
   1 => [1, 3, 5, 7, 9, 11]
 ```
 
-If desired, you can control the key- and value-type of the returned `Dict` with `By{K,V}(f)`.
-See the [documentation](https://timholy.github.io/AggregateBy.jl/dev) for further details.
+Again, see the [documentation](https://timholy.github.io/AggregateBy.jl/dev) for further details.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "How it works" => "explanation.md",
         "Internals" => "advanced.md",
         "Reference" => "reference.md",
     ],

--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -1,6 +1,6 @@
 # Internals and advanced usage
 
-The main design goal is to make `By` robust and easy to use. However, this package also tries to achieve good performance,
+The main design goal is to make `By` robust and easy to use. However, this package also tries to achieve reasonable performance,
 and that often means inferring the key- and value-types of the returned `Dict`. In detail, here is what actually happens for a ficticious operation `aggregator` (e.g., like `count`, `sum`, or `push!`) and "by" function `f`:
 
 - If you call `aggregator(By{K,V}(f), itr)`, it should return a `Dict{K,V}`. It does not rely on inference.
@@ -61,7 +61,7 @@ yields the following results:
 | `vabstract` | 343.598 ns (4 allocations: 432 bytes) | 906.775 ns (4 allocations: 512 bytes) |
 | `vunknown`  | 861.281 ns (26 allocations: 960 bytes) | 1.327 μs (30 allocations: 1.44 KiB) |
 
-In the `vunknown` row, much of the cost in the `By{K,V}(f)` case is the unknown type of `vunknown.container`;
+In the `vunknown` row, much of the cost in the `By{K,V}(f)` case is due to the unknown type of `vunknown.container`;
 the alternative definition
 
 ```julia

--- a/docs/src/explanation.md
+++ b/docs/src/explanation.md
@@ -1,0 +1,56 @@
+```@meta
+CurrentModule = AggregateBy
+DocTestSetup = quote
+    using AggregateBy
+end
+```
+
+# How it works
+
+An object `item` is aggregated using key `f(item)`, i.e. if `operation` is some aggregation operation, then
+
+```julia
+julia> operation(By(f), itr)    # itr is an iterable container
+```
+
+performs aggregations of the form `operation(dict[f(x)], x)`. Let's see a few more examples, this time explaining how they work.
+
+## Examples and their explanation
+
+```jldoctest
+julia> count(By(), "Hello")
+Dict{Char, Int64} with 4 entries:
+  'H' => 1
+  'l' => 2
+  'e' => 1
+  'o' => 1
+```
+
+Here, the aggregation operation is `count`, and the `f` in `By(f)` is the default value `identity` (`identity(x) = x`).
+Consequently, each character got aggregated (by counting) into a container indexed by the character itself.
+Counting aggregates `x` as `dict[f(x)] + 1`, i.e., the `operation` is `+(<dict-entry>, 1)`.
+
+To sum a list by some property of its items:
+
+```jldoctest
+julia> sum(By(isodd), 1:11)
+Dict{Bool, Int64} with 2 entries:
+  0 => 30
+  1 => 36
+```
+
+Note that 30 is the sum of all even numbers in the range, and 36 is the sum of all odd numbers in the range.
+This example illustrates an important point: `f` is applied to each item to generate the *key*, but aggregation uses the raw item. In code, `sum` aggregates `dict[f(x)] + x`, whereas `count` aggregates `dict[f(x)] + 1`.
+
+A third supported aggregation is `push!`:
+
+```jldoctest
+julia> push!(By(isodd), 1:11)
+Dict{Bool, Vector{Int64}} with 2 entries:
+  0 => [2, 4, 6, 8, 10]
+  1 => [1, 3, 5, 7, 9, 11]
+```
+
+In other words, this aggregates via `push!(dict[f(x)], x)`: `dict[f(x)]` returns the aggregated-list for key `f(x)`, and then `x` is `push!`ed onto the list.
+
+If desired, you can control the key- and value-type of the returned `Dict` with `By{K,V}(f)`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,20 +15,9 @@ This package is not yet registered, so you'll have to enter package mode with `]
 
 # Tutorial
 
-All examples assume that you've executed `using AggregateBy` in the current session.
+These examples assume that you've executed `using AggregateBy` in the current session.
 
-To count all the letters in a string:
-
-```jldoctest
-julia> count(By(), "Hello")
-Dict{Char, Int64} with 4 entries:
-  'H' => 1
-  'l' => 2
-  'e' => 1
-  'o' => 1
-```
-
-If you also want to ignore case, then use
+To count all the letters in a string, ignoring case, use
 
 ```jldoctest
 julia> count(By(lowercase), "HelLo")
@@ -39,18 +28,7 @@ Dict{Char, Int64} with 4 entries:
   'o' => 1
 ```
 
-and all characters will be converted to lowercase before counting them.
-
-Or, combine multiple `sum(f, itr)` statements into a single command:
-
-```jldoctest
-julia> sum(By(isodd), 1:11)
-Dict{Bool, Int64} with 2 entries:
-  0 => 30
-  1 => 36
-```
-
-or collect such items for further analysis:
+To collect similar items, use `push!`:
 
 ```jldoctest
 julia> push!(By(isodd), 1:11)

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -5,6 +5,12 @@ Documentation for [AggregateBy](https://github.com/timholy/AggregateBy.jl).
 ```@index
 ```
 
+Currently supported operations:
+
+- `count`
+- `sum`
+- `push!`
+
 ```@autodocs
 Modules = [AggregateBy]
 ```


### PR DESCRIPTION
This keeps the README short and simple, and divides the docs into "tutorial examples" and "examples together with explanation."